### PR TITLE
Output to console

### DIFF
--- a/BuildLoopFixedDev.sh
+++ b/BuildLoopFixedDev.sh
@@ -143,7 +143,7 @@ do
             fi
             echo -e "  Checking out commit ${FIXED_SHA}\n"
             git checkout $FIXED_SHA --recurse-submodules --quiet
-            git branch
+            git --no-pager branch
             echo -e "Continue if no errors reported"
             choose_or_cancel
             options=("Continue" "Cancel")


### PR DESCRIPTION
Avoid opening "git branch" output in vim, instead just print it to output.
Since git 2.16 git branch is listed in pager as default (for example vim), and this would probably confuse a lot of people.

https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.0.txt#L85-L88
